### PR TITLE
address a winrm error at deploy time by chaning when the ps scripts u…

### DIFF
--- a/Deploy-AD/DesiredSateConfig/src/Add-DC2-Domain.ps1
+++ b/Deploy-AD/DesiredSateConfig/src/Add-DC2-Domain.ps1
@@ -18,8 +18,9 @@ configuration Add-DC2-Domain {
     Import-DscResource -ModuleName ActiveDirectoryDsc, NetworkingDsc, xPSDesiredStateConfiguration, xDnsServer, ComputerManagementDsc
     
     [String] $DomainNetbiosName = (Get-NetBIOSName -DomainFQDN $DomainFQDN)
-    [System.Management.Automation.PSCredential]$DomainCreds = New-Object System.Management.Automation.PSCredential ("${DomainNetbiosName}\$($Admincreds.UserName)", $Admincreds.Password)
-
+    # [System.Management.Automation.PSCredential]$DomainCreds = New-Object System.Management.Automation.PSCredential ("${DomainNetbiosName}\$($Admincreds.UserName)", $Admincreds.Password)
+    # modified dpcybuck - fix a timing issue with the Domaincreds so that when the need to make winrm calls comes up the creds are in place
+    [System.Management.Automation.PSCredential]$DomainCreds = $AdminCreds
     $Interface = Get-NetAdapter | Where-Object Name -Like "Ethernet*" | Select-Object -First 1
     $InterfaceAlias = $($Interface.Name)
     $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AdminCreds.Password)

--- a/Deploy-AD/DesiredSateConfig/src/Deploy-ADCS.ps1
+++ b/Deploy-AD/DesiredSateConfig/src/Deploy-ADCS.ps1
@@ -65,8 +65,12 @@ configuration Deploy-ADCS {
                 New-ADCSTemplate -DisplayName Vuln_Template4 -JSON (Get-Content C:\ProgramData\vuln_template4.json -Raw) -Publish
 
                 #ESC6 
-                certutil -config "DC01.doazlab.com\doazlab-DC01-CA" -setreg policy\Editflags +EDITF_ATTRIBUTESUBJECTALTNAME2
-
+                # certutil -config "DC01.doazlab.com\doazlab-DC01-CA" -setreg policy\Editflags +EDITF_ATTRIBUTESUBJECTALTNAME2
+                # modified dpcybuck - Working to fix a deploy error where the domain creds and calls to WinRM error out, I came across this hardcoded vaule
+                # changing it didnot fix the winrm error but leaving it didn't break anything
+                $localCA  = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration' -Name 'Active' -ErrorAction Stop).Active
+                $caConfig = "$env:COMPUTERNAME.$using:DomainFQDN\$localCA"
+                certutil -config $caConfig -setreg policy\Editflags +EDITF_ATTRIBUTESUBJECTALTNAME2
                 #Restart CertSrv
                 Restart-Service -Name CertSvc
 


### PR DESCRIPTION

Change 2 of 3
After forcing standard public ipaddress SKU. I was met with an error when running the ps script for:
"name": "DC01-CreateADForest2-DCPromo" and its call out to Add-DC2-Domain.ps1

Error message: 'DSC Configuration 'Add-DC2-Domain' completed with error(s). Following are the first few: WinRM cannot process the request. The following error with errorcode 0x80090350 occurred while using Negotiate authentication:

My debugging and research seemed to indicate it was something to do with either the timing of when the permissions to do the WinRM call was made, or the permissions themselves.

So I changed

Deploy-AD/DesiredSateConfig/src/Add-DC2-Domain.ps1
NetBIOSName -DomainFQDN $DomainFQDN)
    [System.Management.Automation.PSCredential]$DomainCreds = New-Object System.Management.Automation.PSCredential ("${DomainNetbiosName}\$($Admincreds.UserName)", $Admincreds.Password)

To

    [System.Management.Automation.PSCredential]$DomainCreds = $AdminCreds
By doing it local, it seemed to avoid the issue that the domain name didn't exist yet, and the script was able to run.

Change 3 of 3
In the process of trouble shooting the issue with add-dc2-domain.ps1, I came across something I thought was the fix. But it seems like a small change for the better any way in:

Deploy-AD/DesiredSateConfig/src/Deploy-ADCS.ps1
certutil -config "DC01.doazlab.com\doazlab-DC01-CA" -setreg policy\Editflags +EDITF_ATTRIBUTESUBJECTALTNAME2

I thought the issue with the running of add-dc2-domain.ps1 and the error running the remote WinRM call might be the hardcoded domain name here, doazlab.com\doazlab-dc01-ca
So i changed that to be more dynamically set:

$localCA  = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration' -Name 'Active' -ErrorAction Stop).Active
$caConfig = "$env:COMPUTERNAME.$using:DomainFQDN\$localCA"
certutil -config $caConfig -setreg policy\Editflags +EDITF_ATTRIBUTESUBJECTALTNAME2

If you go look at my main branch of the fork, over at: https://github.com/dpcybuck/DO-LAB
Your going to see a lot of search replace changes.

To test this I needed to change all the references to this DefensiveOrigions/DO-LAB /main and /raw/main to point to my repo so that as the arm's and scripts were running they pointed to the modified "azuredeploy-ad.json" and other things.
To test I had to change the encoded URL in readme.md and readme.html to also, point to dpcybuck/DO-LAB fork

Because of permissions I can't create a branch here. But with 3 changes. I was able to execute the DO-LAB deploy from my fork.

